### PR TITLE
Add RTL detection and translation merging functionality

### DIFF
--- a/src/Languages.php
+++ b/src/Languages.php
@@ -101,7 +101,7 @@ class Languages
         return $this->frontLanguages()->mapWithKeys(function ($locale) use ($routeName, $params) {
             $routeName = str_replace('.lang', '', $routeName);
 
-            return [$locale->slug => route($routeName . '.lang', array_merge($params, ['lang' => $locale->slug]))];
+            return [$locale->slug => route($routeName.'.lang', array_merge($params, ['lang' => $locale->slug]))];
         })->toArray();
     }
 
@@ -115,7 +115,6 @@ class Languages
      * Cache for RTL detection results
      */
     private static array $rtlCache = [];
-
 
     /**
      * Check if language is RTL using Filament translations

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -10,7 +10,6 @@ use Throwable;
 
 class Languages
 {
-
     /**
      * Fallback list for RTL languages not supported by Filament
      * Currently only Pashto (ps) is not in Filament's language files

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -3,11 +3,25 @@
 namespace SmartCms\Lang;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use SmartCms\Lang\Models\Language;
+use Throwable;
 
 class Languages
 {
+
+    /**
+     * Fallback list for RTL languages not supported by Filament
+     * Currently only Pashto (ps) is not in Filament's language files
+     */
+    private const RTL_FALLBACK_LANGUAGES = ['ps'];
+
+    /**
+     * Cache for RTL detection results
+     */
+    private static array $rtlCache = [];
+
     public Collection $languages;
 
     public ?Language $currentLanguage;
@@ -106,17 +120,6 @@ class Languages
     }
 
     /**
-     * Fallback list for RTL languages not supported by Filament
-     * Currently only Pashto (ps) is not in Filament's language files
-     */
-    private const RTL_FALLBACK_LANGUAGES = ['ps'];
-
-    /**
-     * Cache for RTL detection results
-     */
-    private static array $rtlCache = [];
-
-    /**
      * Check if language is RTL using Filament translations
      * Falls back to hardcoded list for unsupported languages
      * Results are cached for performance
@@ -153,5 +156,55 @@ class Languages
         self::$rtlCache[$slug] = $isRtl;
 
         return $isRtl;
+    }
+
+    /**
+     * Get merged translations for current and main language
+     * Used for frontend translation loading
+     *
+     * @param  string|null  $currentLang  Current language code (defaults to app locale)
+     * @param  string|null  $mainLang  Main/fallback language code (defaults to main_lang())
+     * @return array Merged translations with fallback to main language
+     */
+    public function getResultTranslations(?string $currentLang = null, ?string $mainLang = null): array
+    {
+        $currentLang = $currentLang ?? current_lang();
+        $mainLang = $mainLang ?? main_lang();
+
+        $mainTranslationsFile = lang_path("{$mainLang}.json");
+        $currentTranslationsFile = lang_path("{$currentLang}.json");
+
+        try {
+            $mainTranslations = File::exists($mainTranslationsFile)
+                ? File::json($mainTranslationsFile)
+                : [];
+        } catch (Throwable $e) {
+            $mainTranslations = [];
+        }
+
+        // If current and main are the same, return main translations
+        if ($mainTranslationsFile === $currentTranslationsFile) {
+            return $mainTranslations;
+        }
+
+        try {
+            $currentTranslations = File::exists($currentTranslationsFile)
+                ? File::json($currentTranslationsFile)
+                : [];
+        } catch (Throwable $e) {
+            $currentTranslations = [];
+        }
+
+        // Merge with main translations as fallback
+        $resultTranslations = array_merge($mainTranslations, $currentTranslations);
+
+        // Replace empty values with main language translation
+        array_walk($resultTranslations, function (&$value, $key) use ($mainTranslations) {
+            if (empty($value)) {
+                $value = $mainTranslations[$key] ?? '';
+            }
+        });
+
+        return $resultTranslations;
     }
 }

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -101,7 +101,58 @@ class Languages
         return $this->frontLanguages()->mapWithKeys(function ($locale) use ($routeName, $params) {
             $routeName = str_replace('.lang', '', $routeName);
 
-            return [$locale->slug => route($routeName.'.lang', array_merge($params, ['lang' => $locale->slug]))];
+            return [$locale->slug => route($routeName . '.lang', array_merge($params, ['lang' => $locale->slug]))];
         })->toArray();
+    }
+
+    /**
+     * Fallback list for RTL languages not supported by Filament
+     * Currently only Pashto (ps) is not in Filament's language files
+     */
+    private const RTL_FALLBACK_LANGUAGES = ['ps'];
+
+    /**
+     * Cache for RTL detection results
+     */
+    private static array $rtlCache = [];
+
+
+    /**
+     * Check if language is RTL using Filament translations
+     * Falls back to hardcoded list for unsupported languages
+     * Results are cached for performance
+     */
+    public function isRtl(string $slug): bool
+    {
+        return self::isLanguageRtl($slug);
+    }
+
+    /**
+     * Static method to check if language is RTL
+     * Uses Filament's translation system with caching
+     * Can be called without service instantiation
+     *
+     * @param  string  $slug  Language code (e.g., 'ar', 'en', 'ps')
+     * @return bool True if language is RTL
+     */
+    public static function isLanguageRtl(string $slug): bool
+    {
+        // Return cached result if available
+        if (array_key_exists($slug, self::$rtlCache)) {
+            return self::$rtlCache[$slug];
+        }
+
+        // Use Filament's translation system with locale parameter (doesn't change app locale)
+        $direction = __('filament-panels::layout.direction', [], $slug);
+
+        // If translation key is not found, check fallback list
+        $isRtl = str_starts_with($direction, 'filament-panels::')
+            ? in_array($slug, self::RTL_FALLBACK_LANGUAGES)
+            : $direction === 'rtl';
+
+        // Cache the result
+        self::$rtlCache[$slug] = $isRtl;
+
+        return $isRtl;
     }
 }


### PR DESCRIPTION
This PR includes:\n\n- **RTL language detection**: Uses Filament translations with caching and fallback support for unsupported languages like Pashto\n- **Translation merging**: New `getResultTranslations()` method to merge current language translations with main language fallback for frontend use\n\nCode has been reorganized for better structure with constants moved to the top of the class.